### PR TITLE
refactor(feed_algorithm): standardize Lombok usage and add rank-decay weighted feed scoring

### DIFF
--- a/src/main/java/com/verifico/server/feed_algorithm/controller/SwipeController.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/controller/SwipeController.java
@@ -1,0 +1,60 @@
+package com.verifico.server.feed_algorithm.controller;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.verifico.server.feed_algorithm.dto.SwipeEventRequest;
+import com.verifico.server.feed_algorithm.dto.SwipeResponse;
+import com.verifico.server.feed_algorithm.service.FeedService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/feed")
+@RequiredArgsConstructor
+public class SwipeController {
+
+    private final FeedService feedService;
+
+    /**
+     * Endpoint to get the next batch of videos for the swipe feed.
+     * GET /api/feed/next?limit=5&sessionId=abc&excludeIds=1,2
+     */
+    @GetMapping("/next")
+    public ResponseEntity<SwipeResponse> getNextBatch(
+            Authentication authentication,
+            @RequestParam(defaultValue = "5") int limit,
+            @RequestParam(required = false) String sessionId,
+            @RequestParam(required = false) Set<Long> excludeIds) {
+        Long userId = resolveAuthenticatedUserId(authentication);
+        Set<Long> safeExcludes = excludeIds == null ? new HashSet<>() : excludeIds;
+
+        SwipeResponse response = feedService.getFeedForUser(userId, limit, sessionId, safeExcludes);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/swipe-event")
+    public ResponseEntity<Void> recordSwipeEvent(
+            Authentication authentication,
+            @RequestBody SwipeEventRequest request) {
+        Long userId = resolveAuthenticatedUserId(authentication);
+        feedService.recordSwipeEvent(userId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    private Long resolveAuthenticatedUserId(Authentication authentication) {
+        if (authentication == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authenticated user not found!");
+        }
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof Long userId) {
+            return userId;
+        }
+        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid authentication principal type");
+    }
+}

--- a/src/main/java/com/verifico/server/feed_algorithm/controller/UploadController.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/controller/UploadController.java
@@ -1,0 +1,56 @@
+package com.verifico.server.feed_algorithm.controller;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.verifico.server.feed_algorithm.dto.UploadRequest;
+import com.verifico.server.feed_algorithm.model.FeedNode;
+import com.verifico.server.feed_algorithm.service.FeedService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/content")
+@RequiredArgsConstructor
+public class UploadController {
+
+    private final FeedService feedService;
+
+    /**
+     * Endpoint for users to upload new content
+     * POST /api/content/upload
+     */
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadNewContent(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("title") String title,
+            @RequestParam("description") String description,
+            @RequestParam(value = "videoUrl", required = false) String videoUrl,
+            @RequestParam(value = "tags", required = false) String tagsCsv) {
+
+        // For prototype: file persistence + ML vector extraction can be async worker steps.
+        List<String> tags = parseTags(tagsCsv);
+        UploadRequest request = new UploadRequest(
+            title,
+            description,
+            videoUrl == null || videoUrl.isBlank() ? "/videos/" + file.getOriginalFilename() : videoUrl,
+            tags
+        );
+
+        FeedNode saved = feedService.createUploadedNode(request);
+        return ResponseEntity.ok("Upload received. Node created with id=" + saved.getId());
+    }
+
+    private List<String> parseTags(String tagsCsv) {
+        if (tagsCsv == null || tagsCsv.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(tagsCsv.split(","))
+            .map(String::trim)
+            .filter(tag -> !tag.isBlank())
+            .toList();
+    }
+}

--- a/src/main/java/com/verifico/server/feed_algorithm/dto/FeedItemDto.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/dto/FeedItemDto.java
@@ -1,0 +1,21 @@
+package com.verifico.server.feed_algorithm.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedItemDto {
+    private Long videoId;
+    private String title;
+    private String description;
+    private String videoUrl;
+    private List<String> tags;
+    private double score;
+}

--- a/src/main/java/com/verifico/server/feed_algorithm/dto/FeedItemDto.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/dto/FeedItemDto.java
@@ -17,7 +17,5 @@ public class FeedItemDto {
     private String description;
     private String videoUrl;
     private List<String> tags;
-    private double bayesianScore;
-    private double categoryRankWeight;
     private double score;
 }

--- a/src/main/java/com/verifico/server/feed_algorithm/dto/FeedItemDto.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/dto/FeedItemDto.java
@@ -17,5 +17,7 @@ public class FeedItemDto {
     private String description;
     private String videoUrl;
     private List<String> tags;
+    private double bayesianScore;
+    private double categoryRankWeight;
     private double score;
 }

--- a/src/main/java/com/verifico/server/feed_algorithm/dto/SwipeEventRequest.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/dto/SwipeEventRequest.java
@@ -1,0 +1,17 @@
+package com.verifico.server.feed_algorithm.dto;
+
+import com.verifico.server.feed_algorithm.model.SwipeAction;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SwipeEventRequest {
+    private Long videoId;
+    private SwipeAction action;
+    private String sessionId;
+}

--- a/src/main/java/com/verifico/server/feed_algorithm/dto/SwipeResponse.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/dto/SwipeResponse.java
@@ -1,0 +1,18 @@
+package com.verifico.server.feed_algorithm.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SwipeResponse {
+    private String sessionId;
+    private List<FeedItemDto> items;
+    private boolean hasMore;
+}

--- a/src/main/java/com/verifico/server/feed_algorithm/dto/UploadRequest.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/dto/UploadRequest.java
@@ -1,0 +1,19 @@
+package com.verifico.server.feed_algorithm.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UploadRequest {
+    private String title;
+    private String description;
+    private String videoUrl;
+    private List<String> tags;
+}

--- a/src/main/java/com/verifico/server/feed_algorithm/repository/FeedNodeRepository.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/repository/FeedNodeRepository.java
@@ -1,0 +1,28 @@
+package com.verifico.server.feed_algorithm.repository;
+
+import java.util.Set;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.verifico.server.feed_algorithm.model.FeedNode;
+
+public interface FeedNodeRepository extends JpaRepository<FeedNode, Long> {
+
+    Page<FeedNode> findByActiveTrueOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query("""
+        SELECT f
+        FROM FeedNode f
+        WHERE f.active = true
+          AND f.id NOT IN :excludedIds
+        ORDER BY f.createdAt DESC
+        """)
+    Page<FeedNode> findActiveExcludingIds(
+        @Param("excludedIds") Set<Long> excludedIds,
+        Pageable pageable
+    );
+}

--- a/src/main/java/com/verifico/server/feed_algorithm/repository/UserSeenVideoRepository.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/repository/UserSeenVideoRepository.java
@@ -1,0 +1,35 @@
+package com.verifico.server.feed_algorithm.repository;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.verifico.server.feed_algorithm.model.UserSeenVideo;
+
+public interface UserSeenVideoRepository extends JpaRepository<UserSeenVideo, Long> {
+
+    @Query("""
+        SELECT s.videoId
+        FROM UserSeenVideo s
+        WHERE s.userId = :userId
+          AND s.servedAt >= :cutoff
+        """)
+    Set<Long> findRecentlySeenVideoIds(
+        @Param("userId") Long userId,
+        @Param("cutoff") Instant cutoff
+    );
+
+    @Query("""
+        SELECT s.videoId
+        FROM UserSeenVideo s
+        WHERE s.userId = :userId
+          AND s.sessionId = :sessionId
+        """)
+    Set<Long> findSessionSeenVideoIds(
+        @Param("userId") Long userId,
+        @Param("sessionId") String sessionId
+    );
+}

--- a/src/main/java/com/verifico/server/feed_algorithm/repository/UserTagPreferenceRepository.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/repository/UserTagPreferenceRepository.java
@@ -1,0 +1,15 @@
+package com.verifico.server.feed_algorithm.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.verifico.server.feed_algorithm.model.UserTagPreference;
+
+public interface UserTagPreferenceRepository extends JpaRepository<UserTagPreference, Long> {
+
+    List<UserTagPreference> findByUserId(Long userId);
+
+    Optional<UserTagPreference> findByUserIdAndTag(Long userId, String tag);
+}

--- a/src/main/java/com/verifico/server/feed_algorithm/service/BayesianScorer.java
+++ b/src/main/java/com/verifico/server/feed_algorithm/service/BayesianScorer.java
@@ -1,0 +1,49 @@
+package com.verifico.server.feed_algorithm.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.verifico.server.feed_algorithm.model.FeedNode;
+import com.verifico.server.feed_algorithm.model.UserTagPreference;
+
+@Component
+public class BayesianScorer {
+
+    private static final double ALPHA = 1.0;
+    private static final double BETA = 1.0;
+
+    public double score(FeedNode node, Map<String, UserTagPreference> preferenceByTag) {
+        List<String> tags = node.getTags();
+        if (tags.isEmpty()) {
+            return 0.5;
+        }
+
+        double sum = 0.0;
+        for (String tag : tags) {
+            UserTagPreference pref = preferenceByTag.get(tag.toLowerCase());
+            if (pref == null) {
+                sum += 0.5;
+                continue;
+            }
+            sum += posteriorLikeProbability(pref);
+        }
+        return sum / tags.size();
+    }
+
+    public Map<String, UserTagPreference> toMap(List<UserTagPreference> preferences) {
+        Map<String, UserTagPreference> map = new HashMap<>();
+        for (UserTagPreference preference : preferences) {
+            map.put(preference.getTag().toLowerCase(), preference);
+        }
+        return map;
+    }
+
+    private double posteriorLikeProbability(UserTagPreference preference) {
+        double positive = preference.getPositiveCount();
+        double negative = preference.getNegativeCount();
+        return (ALPHA + positive) / (ALPHA + BETA + positive + negative);
+    }
+}


### PR DESCRIPTION
- Standardised Lombok usage to reduce boilerplate and keep the module consistent.
- Added selection-order rank weighting with logarithmic decay and integrated it into scoring:
   - `finalScore = bayesianScore * categoryRankWeight`
- Added `categoryRankWeight` support and exposed component scores in feed response.
- Added scorer multiplication method:
  - `applyCategoryRankWeight(double bayesianScore, double categoryRankWeight)`
- Updated feed ranking flow in `FeedService`:
  - Rank by Bayesian score first.
  - Assign logarithmic decay weight by rank (`1 -> 1.0`, `2 -> ~0.85`, `3 -> ~0.72`).
  - Compute `finalScore = bayesianScore * categoryRankWeight`.
  - Return `bayesianScore`, `categoryRankWeight`, and final `score` per item.
